### PR TITLE
[CI] replace usage of `miniconda` with `micromamba`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           environment-name: roman-data-workshop-env
           environment-file: 00_install/environment.yml
+          create-args: >-
+            conda
           cache-environment: true
           cache-downloads: true
           init-shell: bash
@@ -56,6 +58,8 @@ jobs:
         with:
           environment-name: roman-data-workshop-env
           environment-file: 00_install/environment.yml
+          create-args: >-
+            conda
           cache-environment: true
           cache-downloads: true
           init-shell: bash
@@ -77,6 +81,8 @@ jobs:
         with:
           environment-name: roman-data-workshop-env
           environment-file: 00_install/environment.yml
+          create-args: >-
+            conda
           cache-environment: true
           cache-downloads: true
           init-shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,19 @@ concurrency:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: micromamba-shell {0}
 
 jobs:
+  date:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+        id: date        
+        shell: bash
+    outputs:
+      date: ${{ steps.date.outputs.date }}
   build:
+    needs: [ date ]
     name: build environment
     runs-on: ubuntu-latest
     steps:
@@ -34,9 +43,12 @@ jobs:
           environment-file: 00_install/environment.yml
           create-args: >-
             conda
-          cache-environment: true
           cache-downloads: true
-          init-shell: bash
+          cache-downloads-key: downloads-${{ needs.date.outputs.date }}
+          cache-environment: true
+          cache-environment-key: environment-${{ needs.date.outputs.date }}
+          init-shell: none
+          generate-run-shell: true
       - run: python ./00_install/verify_install.py
       - run: conda env export > roman-data-workshop-env-${{ github.sha }}.yml
       - uses: actions/upload-artifact@v3.1.0
@@ -44,8 +56,8 @@ jobs:
           name: roman-data-workshop-env-${{ github.sha }}.yml
           path: roman-data-workshop-env-${{ github.sha }}.yml
   data:
+    needs: [ date, build ]
     name: download data
-    needs: [ build ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -60,15 +72,18 @@ jobs:
           environment-file: 00_install/environment.yml
           create-args: >-
             conda
-          cache-environment: true
           cache-downloads: true
-          init-shell: bash
+          cache-downloads-key: downloads-${{ needs.date.outputs.date }}
+          cache-environment: true
+          cache-environment-key: environment-${{ needs.date.outputs.date }}
+          init-shell: none
+          generate-run-shell: true
         if: steps.data_cache.outputs.cache-hit != 'true'
       - run: python data/download.py
         if: steps.data_cache.outputs.cache-hit != 'true'
   test:
+    needs: [ date, build, data ]
     name: run notebooks
-    needs: [ build, data ]
     runs-on: ubuntu-latest
     env:
       CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
@@ -83,9 +98,12 @@ jobs:
           environment-file: 00_install/environment.yml
           create-args: >-
             conda
-          cache-environment: true
           cache-downloads: true
-          init-shell: bash
+          cache-downloads-key: downloads-${{ needs.date.outputs.date }}
+          cache-environment: true
+          cache-environment-key: environment-${{ needs.date.outputs.date }}
+          init-shell: none
+          generate-run-shell: true
       - run: echo "name=crds_context::$(crds list --operational-context)" >> $GITHUB_OUTPUT
         id: crds_context
       - uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: roman-data-workshop-env
           environment-file: 00_install/environment.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           path: data/
           key: data-${{ hashFiles('data/download.py') }}
-      - uses: conda-incubator/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: roman-data-workshop-env
           environment-file: 00_install/environment.yml
@@ -69,7 +69,7 @@ jobs:
       CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: roman-data-workshop-env
           environment-file: 00_install/environment.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
           cache-environment: true
           cache-downloads: true
           init-shell: bash
-      - run: echo "::set-output name=crds_context::$(crds list --operational-context)"
+      - run: echo "name=crds_context::$(crds list --operational-context)" >> $GITHUB_OUTPUT
         id: crds_context
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 
 defaults:
   run:
-    shell: bash -el {0}
+    shell: bash -l {0}
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash -el {0}
 
 jobs:
   build:
@@ -24,17 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: conda-incubator/setup-micromamba@v1
         with:
-          path: |
-            ~/conda_pkgs_dir
-            /usr/share/miniconda/envs/roman-data-workshop-env
-          key: conda-${{ runner.os }}-${{ hashFiles('00_install/environment.yml') }}-${{ github.sha }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: roman-data-workshop-env
+          environment-name: roman-data-workshop-env
           environment-file: 00_install/environment.yml
-          use-only-tar-bz2: true
+          cache-environment: true
+          cache-downloads: true
+          init-shell: bash
       - run: python ./00_install/verify_install.py
       - run: conda env export > roman-data-workshop-env-${{ github.sha }}.yml
       - uses: actions/upload-artifact@v3.1.0
@@ -52,18 +48,13 @@ jobs:
         with:
           path: data/
           key: data-${{ hashFiles('data/download.py') }}
-      - uses: actions/cache@v3
+      - uses: conda-incubator/setup-micromamba@v1
         with:
-          path: |
-            ~/conda_pkgs_dir
-            /usr/share/miniconda/envs/roman-data-workshop-env
-          key: conda-${{ runner.os }}-${{ hashFiles('00_install/environment.yml') }}-${{ github.sha }}
-        if: steps.data_cache.outputs.cache-hit != 'true'
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: roman-data-workshop-env
+          environment-name: roman-data-workshop-env
           environment-file: 00_install/environment.yml
-          use-only-tar-bz2: true
+          cache-environment: true
+          cache-downloads: true
+          init-shell: bash
         if: steps.data_cache.outputs.cache-hit != 'true'
       - run: python data/download.py
         if: steps.data_cache.outputs.cache-hit != 'true'
@@ -78,17 +69,13 @@ jobs:
       CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: conda-incubator/setup-micromamba@v1
         with:
-          path: |
-            ~/conda_pkgs_dir
-            /usr/share/miniconda/envs/roman-data-workshop-env
-          key: conda-${{ runner.os }}-${{ hashFiles('00_install/environment.yml') }}-${{ github.sha }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: roman-data-workshop-env
+          environment-name: roman-data-workshop-env
           environment-file: 00_install/environment.yml
-          use-only-tar-bz2: true
+          cache-environment: true
+          cache-downloads: true
+          init-shell: bash
       - run: echo "::set-output name=crds_context::$(crds list --operational-context)"
         id: crds_context
       - uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ on:
       - '**/*.yaml'
       - '**/*.py'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash -l {0}


### PR DESCRIPTION
the `setup-micromamba` action is both faster and also includes caching; this reduces environment creation time and also boilerplate code