### PR TITLE
update link to latest asdf docs

### DIFF
--- a/01-Introduction/01-Introduction.ipynb
+++ b/01-Introduction/01-Introduction.ipynb
@@ -148,7 +148,7 @@
    "source": [
     "- **Original ASDF Paper:** https://www.sciencedirect.com/science/article/pii/S2213133715000645\n",
     "- **Standard Documentation:** https://asdf-standard.readthedocs.io/en/latest/\n",
-    "- **Python package documentation:** https://asdf.readthedocs.io/en/stable/\n",
+    "- **Python package documentation:** https://asdf.readthedocs.io/en/latest/\n",
     "- **Tutorial github respository:** https://github.com/spacetelescope/scipy2022tutorial"
    ]
   },


### PR DESCRIPTION
Updates a docs link to point to the latest asdf docs (instead of the infrequently updated "stable" docs).